### PR TITLE
Clear schemas on cluster reconnect

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -863,7 +863,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public void sendStateToCluster() throws ExecutionException, InterruptedException {
         userCodeDeploymentService.deploy(this);
-        schemaService.sendAllSchemas();
+        schemaService.clearAndSendAllSchemasAsync();
         queryCacheContext.recreateAllCaches();
         proxyManager.createDistributedObjectsOnCluster();
     }


### PR DESCRIPTION
Clearing schemas on cluster reconnect and sending the remote schema registration before the local schema registration.